### PR TITLE
core/vote: switch from reactions to components

### DIFF
--- a/src/Commands/AbstimmungsCommand.cs
+++ b/src/Commands/AbstimmungsCommand.cs
@@ -53,10 +53,6 @@ public sealed class AbstimmungsCommand : ApplicationCommandsModule
             return;
         }
 
-        var embed = new DiscordEmbedBuilder();
-        embed.WithTitle("Entbannungsabstimmung");
-        embed.Timestamp = DateTimeOffset.UtcNow;
-        embed.WithDescription($"{ctx.Channel.Name} | ({ctx.Channel.Mention}) steht zur Abstimmung bereit.");
         ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
         DiscordChannel votechannel = ctx.Guild.GetChannel(votechannelid);
         var idOfAntragChannel = ctx.Channel.Id.ToString();
@@ -71,8 +67,7 @@ public sealed class AbstimmungsCommand : ApplicationCommandsModule
 
         var voteembed = MessageGenerator.getVoteEmbedInRunning(ctx.Channel, now16h, 0, 0, 3);
         var votechannelmessage = new DiscordMessageBuilder().AddComponents(votebuttons).AddEmbed(voteembed).WithContent(Helperfunctions.getTeamPing());
-        var votemessage = await votechannel.SendMessageAsync(
-            votechannelmessage.AddEmbed(embed));
+        var votemessage = await votechannel.SendMessageAsync(votechannelmessage);
 
         //move channel to vote category
         await ctx.EditResponseAsync(

--- a/src/Commands/AbstimmungsCommand.cs
+++ b/src/Commands/AbstimmungsCommand.cs
@@ -70,7 +70,7 @@ public sealed class AbstimmungsCommand : ApplicationCommandsModule
         var now16h = now + 57600;
 
         var voteembed = MessageGenerator.getVoteEmbedInRunning(ctx.Channel, now16h, 0, 0, 3);
-        var votechannelmessage = new DiscordMessageBuilder().AddComponents(votebuttons).AddEmbed(voteembed);
+        var votechannelmessage = new DiscordMessageBuilder().AddComponents(votebuttons).AddEmbed(voteembed).WithContent(Helperfunctions.getTeamPing());
         var votemessage = await votechannel.SendMessageAsync(
             votechannelmessage.AddEmbed(embed));
 

--- a/src/Eventhandler/UnbanGuild/onComponentInteraction.cs
+++ b/src/Eventhandler/UnbanGuild/onComponentInteraction.cs
@@ -3,6 +3,7 @@
 using AGC_Entbannungssystem.Entities;
 using AGC_Entbannungssystem.Helpers;
 using AGC_Entbannungssystem.Services;
+using AGC_Entbannungssystem.Tasks;
 using DisCatSharp;
 using DisCatSharp.ApplicationCommands;
 using DisCatSharp.Entities;
@@ -54,6 +55,7 @@ public class onComponentInteraction : ApplicationCommandsModule
                             await Helperfunctions.removeVoteFromAntrag(e);
                             await e.Interaction.EditOriginalResponseAsync(
                                 new DiscordWebhookBuilder().WithContent("Dein vorheriger Vote wurde entfernt."));
+                            await UpdateVoteMessages.UpdateSingleVoteMessage(CurrentApplicationData.Client, e.Message.Id);
                             return;
                         }
 
@@ -61,6 +63,7 @@ public class onComponentInteraction : ApplicationCommandsModule
                         await Helperfunctions.addVoteToAntrag(e, true);
                         await e.Interaction.EditOriginalResponseAsync(
                             new DiscordWebhookBuilder().WithContent($"Dein Vote wurde gezählt! Stimme: **Ja**"));
+                        await UpdateVoteMessages.UpdateSingleVoteMessage(CurrentApplicationData.Client, e.Message.Id);
                     }
                     else if (cid.StartsWith("vote_no_"))
                     {
@@ -69,12 +72,14 @@ public class onComponentInteraction : ApplicationCommandsModule
                             await Helperfunctions.removeVoteFromAntrag(e);
                             await e.Interaction.EditOriginalResponseAsync(
                                 new DiscordWebhookBuilder().WithContent("Dein vorheriger Vote wurde entfernt."));
+                            await UpdateVoteMessages.UpdateSingleVoteMessage(CurrentApplicationData.Client, e.Message.Id);
                             return;
                         }
 
                         await Helperfunctions.addVoteToAntrag(e, false);
                         await e.Interaction.EditOriginalResponseAsync(
                             new DiscordWebhookBuilder().WithContent($"Dein Vote wurde gezählt! Stimme: **Nein**"));
+                        await UpdateVoteMessages.UpdateSingleVoteMessage(CurrentApplicationData.Client, e.Message.Id);
                     }
                     else
                     {

--- a/src/Eventhandler/UnbanGuild/onComponentInteraction.cs
+++ b/src/Eventhandler/UnbanGuild/onComponentInteraction.cs
@@ -35,10 +35,9 @@ public class onComponentInteraction : ApplicationCommandsModule
                 {
                     await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource,
                         new DiscordInteractionResponseBuilder().AsEphemeral());
-                    ulong messageid = ulong.Parse(cid.Split("_")[1]);
                     ulong channelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
                     DiscordChannel channel = await client.GetChannelAsync(channelid);
-                    DiscordMessage message = await channel.GetMessageAsync(messageid);
+                    DiscordMessage message = await channel.GetMessageAsync(e.Message.Id);
                     if (message == null)
                     {
                         await e.Interaction.EditOriginalResponseAsync(
@@ -48,7 +47,7 @@ public class onComponentInteraction : ApplicationCommandsModule
 
                     var existingVote = await Helperfunctions.UserHasVoted(e); // returns Positive, Negative or null
 
-                    if (cid == "vote_yes_" + channelid)
+                    if (cid.StartsWith("vote_yes_"))
                     {
                         if (existingVote != null)
                         {
@@ -63,7 +62,7 @@ public class onComponentInteraction : ApplicationCommandsModule
                         await e.Interaction.EditOriginalResponseAsync(
                             new DiscordWebhookBuilder().WithContent($"Dein Vote wurde gezählt! Stimme: **Ja**"));
                     }
-                    else if (cid == "vote_no_" + channelid)
+                    else if (cid.StartsWith("vote_no_"))
                     {
                         if (existingVote != null)
                         {
@@ -92,6 +91,11 @@ public class onComponentInteraction : ApplicationCommandsModule
                         "Es ist ein Fehler aufgetreten. Bitte versuche es später erneut. Der Fehler wurde automatisch an den Entwickler weitergeleitet.");
                     embed.WithColor(DiscordColor.Red);
                     await e.Interaction.EditOriginalResponseAsync(new DiscordWebhookBuilder().AddEmbed(embed));
+                    client.Logger.LogError($"Exception occured: {exception.GetType()}: {exception.Message}");
+                    // print line number
+                    client.Logger.LogError($"Line: {exception.StackTrace?.Split('\n')[0]}");
+                    // log stack trace
+                    client.Logger.LogError(exception.StackTrace);
                     await ErrorReporting.SendErrorToDev(client, e.User, exception);
                 }
 

--- a/src/Helpers/Helperfunctions.cs
+++ b/src/Helpers/Helperfunctions.cs
@@ -55,8 +55,8 @@ public static class Helperfunctions
         cmd.Parameters.AddWithValue("messageid", (long)interaction.Message.Id);
         await cmd.ExecuteNonQueryAsync();
 
-        await using var cmd2 = new NpgsqlCommand("INSERT INTO abstimmungsvotes (vote_id, user_id, votevalue) VALUES (@voteid, @userid, @votevalue)", conn);
-        cmd2.Parameters.AddWithValue("voteid", interaction.Channel.Id + interaction.Message.Id);
+        await using var cmd2 = new NpgsqlCommand("INSERT INTO abstimmungen_teamler (vote_id, user_id, votevalue) VALUES (@voteid, @userid, @votevalue)", conn);
+        cmd2.Parameters.AddWithValue("voteid", (interaction.Channel.Id + interaction.Message.Id).ToString());
         cmd2.Parameters.AddWithValue("userid", (long)interaction.User.Id);
         cmd2.Parameters.AddWithValue("votevalue", positiveVote ? 1 : 0);
         await cmd2.ExecuteNonQueryAsync();
@@ -84,8 +84,9 @@ public static class Helperfunctions
         cmd.Parameters.AddWithValue("messageid", (long)interaction.Message.Id);
         await cmd.ExecuteNonQueryAsync();
 
-        await using var cmd2 = new NpgsqlCommand("DELETE FROM abstimmungsvotes WHERE vote_id = @voteid AND user_id = @userid", conn);
-        cmd2.Parameters.AddWithValue("voteid", interaction.Channel.Id + interaction.Message.Id);
+        await using var cmd2 = new NpgsqlCommand("DELETE FROM abstimmungen_teamler WHERE vote_id = @voteid AND user_id = @userid", conn);
+        var voteId = (long)interaction.Channel.Id + (long)interaction.Message.Id;
+        cmd2.Parameters.AddWithValue("voteid", voteId.ToString());
         cmd2.Parameters.AddWithValue("userid", (long)interaction.User.Id);
         await cmd2.ExecuteNonQueryAsync();
     }
@@ -96,8 +97,9 @@ public static class Helperfunctions
         var dbstring = DbString();
         await using var conn = new NpgsqlConnection(dbstring);
         await conn.OpenAsync();
-        await using var cmd = new NpgsqlCommand("SELECT votevalue FROM abstimmungsvotes WHERE vote_id = @voteid AND user_id = @userid", conn);
-        cmd.Parameters.AddWithValue("voteid", interaction.Channel.Id + interaction.Message.Id);
+        await using var cmd = new NpgsqlCommand("SELECT votevalue FROM abstimmungen_teamler WHERE vote_id = @voteid AND user_id = @userid", conn);
+        var voteId = (long)interaction.Channel.Id + (long)interaction.Message.Id;
+        cmd.Parameters.AddWithValue("voteid", voteId.ToString());
         cmd.Parameters.AddWithValue("userid", (long)interaction.User.Id);
 
         await using var reader = await cmd.ExecuteReaderAsync();

--- a/src/Helpers/Helperfunctions.cs
+++ b/src/Helpers/Helperfunctions.cs
@@ -27,6 +27,11 @@ public static class Helperfunctions
         return $"Host={dbhost};Username={dbuser};Password={dbpassword};Database={databasename}";
     }
 
+    public static string getTeamPing()
+    {
+        return $"<@&{BotConfigurator.GetConfig("MainConfig", "PingRoleId")}>";
+    }
+
 
     public static async Task<List<BannSystemReport?>?> GetBannsystemReports(DiscordUser user)
     {

--- a/src/Helpers/Helperfunctions.cs
+++ b/src/Helpers/Helperfunctions.cs
@@ -271,4 +271,16 @@ public static class Helperfunctions
     {
         return reports.Any(report => report.active);
     }
+
+    public static int getVoteColor(int pvotes, int nvotes)
+    {
+        if (pvotes == 0 && nvotes == 0)
+            return -1; // No votes → gray (default)
+        if (pvotes == nvotes)
+            return 2; // Tie → yellow
+        if (pvotes > nvotes)
+            return 1; // More positive votes → green
+
+        return 0; // More negative votes → red
+    }
 }

--- a/src/Helpers/MessageGenerator.cs
+++ b/src/Helpers/MessageGenerator.cs
@@ -62,7 +62,7 @@ public static class MessageGenerator
         var embed = new DiscordEmbedBuilder();
         embed.WithTitle("Abstimmung läuft!");
         embed.WithDescription(
-            $"Die Abstimmung für den Antrag {votechannel.Name} ({votechannel.Mention}) steht bereit!\n" +
+            $"Die Abstimmung für den Antrag ``{votechannel.Name}`` | ({votechannel.Mention}) steht bereit!\n" +
             $"**Positive Stimmen:** {positiveVotes}\n" +
             $"**Negative Stimmen:** {negativeVotes}\n" +
             $"Die Abstimmung läuft bis <t:{targetTimestamp}:f> (<t:{targetTimestamp}:R>)\n\n" +
@@ -83,7 +83,7 @@ public static class MessageGenerator
         var embed = new DiscordEmbedBuilder();
         embed.WithTitle("Abstimmung beendet!");
         embed.WithDescription(
-            $"Die Abstimmung für den Antrag {votechannel.Name} ({votechannel.Mention}) ist beendet!\n" +
+            $"Die Abstimmung für den Antrag ``{votechannel.Name}`` | ({votechannel.Mention}) ist beendet!\n" +
             $"**Positive Stimmen:** {positiveVotes}\n" +
             $"**Negative Stimmen:** {negativeVotes}\n" +
             $"Die Abstimmung endete am <t:{targetTimestamp}:f> (<t:{targetTimestamp}:R>)\n\n");

--- a/src/Helpers/MessageGenerator.cs
+++ b/src/Helpers/MessageGenerator.cs
@@ -49,4 +49,56 @@ public static class MessageGenerator
         embeds.Add(embed3.Build());
         return embeds;
     }
+
+    public static DiscordEmbed getVoteEmbedInRunning(DiscordChannel votechannel, long targetTimestamp, int negativeVotes = 0, int positiveVotes = 0, int resultForColor = 0)
+    {
+        var color = resultForColor switch
+        {
+            0 => DiscordColor.Red, // more negative votes
+            1 => DiscordColor.Green, // more positive votes
+            2 => DiscordColor.Yellow, // tie
+            _ => DiscordColor.Gray // default color if no votes yet
+        };
+        var embed = new DiscordEmbedBuilder();
+        embed.WithTitle("Abstimmung läuft!");
+        embed.WithDescription(
+            $"Die Abstimmung für den Antrag {votechannel.Name} ({votechannel.Mention}) steht bereit!\n" +
+            $"**Positive Stimmen:** {positiveVotes}\n" +
+            $"**Negative Stimmen:** {negativeVotes}\n" +
+            $"Die Abstimmung läuft bis <t:{targetTimestamp}:f> (<t:{targetTimestamp}:R>)\n\n" +
+            $"-# Die anzahl der stimmen wird alle 5 Minuten aktualisiert.\n");
+        embed.WithColor(color);
+        return embed.Build();
+    }
+
+    public static DiscordEmbed getVoteEmbedFinished(DiscordChannel votechannel, long targetTimestamp, int negativeVotes = 0, int positiveVotes = 0, int resultForColor = 0)
+    {
+        var color = resultForColor switch
+        {
+            0 => DiscordColor.Red, // more negative votes
+            1 => DiscordColor.Green, // more positive votes
+            2 => DiscordColor.Yellow, // tie
+            _ => DiscordColor.Gray // default color if no votes yet
+        };
+        var embed = new DiscordEmbedBuilder();
+        embed.WithTitle("Abstimmung beendet!");
+        embed.WithDescription(
+            $"Die Abstimmung für den Antrag {votechannel.Name} ({votechannel.Mention}) ist beendet!\n" +
+            $"**Positive Stimmen:** {positiveVotes}\n" +
+            $"**Negative Stimmen:** {negativeVotes}\n" +
+            $"Die Abstimmung endete am <t:{targetTimestamp}:f> (<t:{targetTimestamp}:R>)\n\n");
+        embed.WithColor(color);
+        return embed.Build();
+    }
+
+    public static DiscordEmbed getVoteEmbedCanceled(DiscordChannel votechannel, long targetTimestamp)
+    {
+        var embed = new DiscordEmbedBuilder();
+        embed.WithTitle("Abstimmung abgebrochen!");
+        embed.WithDescription(
+            $"Die Abstimmung für den Antrag {votechannel.Name} ({votechannel.Mention}) wurde abgebrochen!\n" +
+            $"Die Abstimmung wurde am <t:{targetTimestamp}:f> (<t:{targetTimestamp}:R>) abgebrochen.\n\n");
+        embed.WithColor(DiscordColor.DarkRed);
+        return embed.Build();
+    }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -187,6 +187,7 @@ internal sealed class Program
         _ = CheckExpiredVotes.Run(client);
         _ = CheckExpiredBlock.Run(client);
         _ = FillAutocompletions.Run(client);
+        _ = UpdateVoteMessages.Run(client);
     }
 
 

--- a/src/Tasks/CheckExpiredVotes.cs
+++ b/src/Tasks/CheckExpiredVotes.cs
@@ -38,7 +38,8 @@ public class CheckExpiredVotes
                     ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
                     DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
                     DiscordMessage message = await votechannel.GetMessageAsync(messageid);
-                    DiscordEmbed emb = MessageGenerator.getVoteEmbedFinished(votechannel, reader.GetInt64(2),
+                    var nowtimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                    DiscordEmbed emb = MessageGenerator.getVoteEmbedFinished(votechannel, nowtimestamp,
                         reader.GetInt32(5), reader.GetInt32(4));
 
                     DiscordMessageBuilder builder = new DiscordMessageBuilder()

--- a/src/Tasks/CheckExpiredVotes.cs
+++ b/src/Tasks/CheckExpiredVotes.cs
@@ -38,8 +38,11 @@ public class CheckExpiredVotes
                     DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
                     DiscordMessage message = await votechannel.GetMessageAsync(messageid);
                     var nowtimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                    var pvotes = reader.GetInt32(4);
+                    var nvotes = reader.GetInt32(5);
+                    var colorInt = Helperfunctions.getVoteColor(pvotes, nvotes);
                     DiscordEmbed emb = MessageGenerator.getVoteEmbedFinished(antragschannel, nowtimestamp,
-                        reader.GetInt32(5), reader.GetInt32(4));
+                        nvotes, pvotes, colorInt);
                     try
                     {
                         // delete message

--- a/src/Tasks/CheckExpiredVotes.cs
+++ b/src/Tasks/CheckExpiredVotes.cs
@@ -61,7 +61,7 @@ public class CheckExpiredVotes
                 await using var cmd3 = new NpgsqlCommand();
                 cmd3.Connection = conn2;
                 // voteid is channelid+messageid
-                cmd3.CommandText = "DELETE FROM abstimmungen_teamler WHERE voteid IN " +
+                cmd3.CommandText = "DELETE FROM abstimmungen_teamler WHERE vote_id IN " +
                                    "(SELECT channel_id || '_' || message_id FROM abstimmungen WHERE expires_at < @endtime)";
                 cmd3.Parameters.AddWithValue("endtime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
                 await cmd3.ExecuteNonQueryAsync();

--- a/src/Tasks/UpdateVoteMessages.cs
+++ b/src/Tasks/UpdateVoteMessages.cs
@@ -1,0 +1,80 @@
+﻿using AGC_Entbannungssystem.Helpers;
+using AGC_Entbannungssystem.Services;
+using DisCatSharp;
+using DisCatSharp.Entities;
+using DisCatSharp.Enums;
+using Npgsql;
+
+namespace AGC_Entbannungssystem.Tasks;
+
+public class UpdateVoteMessages
+{
+    public static async Task Run(DiscordClient client)
+    {
+        // structure of abstimmungen table: channel_id, message_id, expires_at, created_by, pvotes, nvotes
+        while (true)
+        {
+            try
+            {
+                string dbstring = Helperfunctions.DbString();
+                await using var conn = new NpgsqlConnection(dbstring);
+                await conn.OpenAsync();
+                await using NpgsqlCommand cmd = new NpgsqlCommand();
+                cmd.Connection = conn;
+                cmd.CommandText = "SELECT * FROM abstimmungen WHERE expires_at > @currenttime";
+                cmd.Parameters.AddWithValue("currenttime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+                await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    long antragchannelid = reader.GetInt64(0);
+                    var votemessageid = (ulong)reader.GetInt64(1);
+
+                    // get messages from id in vote channel
+                    ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
+                    DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
+                    DiscordMessage message = await votechannel.GetMessageAsync(votemessageid);
+
+                    long expiresAt = reader.GetInt64(2);
+
+                    var pvotes = reader.GetInt32(4);
+                    var nvotes = reader.GetInt32(5);
+                    int color = getVoteColor(pvotes, nvotes);
+
+                    DiscordEmbed vembed = MessageGenerator.getVoteEmbedInRunning(votechannel, expiresAt, nvotes, pvotes, color);
+
+                    var votebuttons = new List<DiscordButtonComponent>()
+                    {
+                        new(ButtonStyle.Secondary, "vote_yes_" + antragchannelid, "👍 Ja"),
+                        new(ButtonStyle.Secondary, "vote_no_" + antragchannelid, "👎 Nein")
+                    };
+                    DiscordMessageBuilder builder = new DiscordMessageBuilder()
+                        .WithContent(Helperfunctions.getTeamPing())
+                        .AddComponents(votebuttons)
+                        .AddEmbed(vembed);
+
+                    await message.ModifyAsync(builder);
+                    await conn.CloseAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                //
+            }
+            await Task.Delay(TimeSpan.FromMinutes(5));
+        }
+    }
+
+    private static int getVoteColor(int pvotes, int nvotes)
+    {
+        if (pvotes == 0 && nvotes == 0)
+            return -1; // No votes → gray (default)
+        if (pvotes == nvotes)
+            return 2; // Tie → yellow
+        if (pvotes > nvotes)
+            return 1; // More positive votes → green
+
+        return 0; // More negative votes → red
+    }
+    
+}

--- a/src/Tasks/UpdateVoteMessages.cs
+++ b/src/Tasks/UpdateVoteMessages.cs
@@ -7,11 +7,10 @@ using Npgsql;
 
 namespace AGC_Entbannungssystem.Tasks;
 
-public class UpdateVoteMessages
+public static class UpdateVoteMessages
 {
     public static async Task Run(DiscordClient client)
     {
-        // structure of abstimmungen table: channel_id, message_id, expires_at, created_by, pvotes, nvotes
         while (true)
         {
             try
@@ -19,62 +18,89 @@ public class UpdateVoteMessages
                 string dbstring = Helperfunctions.DbString();
                 await using var conn = new NpgsqlConnection(dbstring);
                 await conn.OpenAsync();
-                await using NpgsqlCommand cmd = new NpgsqlCommand();
-                cmd.Connection = conn;
-                cmd.CommandText = "SELECT * FROM abstimmungen WHERE expires_at > @currenttime";
-                cmd.Parameters.AddWithValue("currenttime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-                await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync();
 
+                await using var cmd =
+                    new NpgsqlCommand("SELECT * FROM abstimmungen WHERE expires_at > @currenttime", conn);
+                cmd.Parameters.AddWithValue("currenttime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+                await using var reader = await cmd.ExecuteReaderAsync();
                 while (await reader.ReadAsync())
                 {
                     long antragchannelid = reader.GetInt64(0);
-                    var votemessageid = (ulong)reader.GetInt64(1);
-
-                    // get messages from id in vote channel
-                    ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
-                    DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
-                    DiscordMessage message = await votechannel.GetMessageAsync(votemessageid);
-
+                    ulong messageId = (ulong)reader.GetInt64(1);
                     long expiresAt = reader.GetInt64(2);
+                    int pvotes = reader.GetInt32(4);
+                    int nvotes = reader.GetInt32(5);
 
-                    var pvotes = reader.GetInt32(4);
-                    var nvotes = reader.GetInt32(5);
-                    int color = getVoteColor(pvotes, nvotes);
-
-                    DiscordEmbed vembed = MessageGenerator.getVoteEmbedInRunning(votechannel, expiresAt, nvotes, pvotes, color);
-
-                    var votebuttons = new List<DiscordButtonComponent>()
-                    {
-                        new(ButtonStyle.Secondary, "vote_yes_" + antragchannelid, "👍 Ja"),
-                        new(ButtonStyle.Secondary, "vote_no_" + antragchannelid, "👎 Nein")
-                    };
-                    DiscordMessageBuilder builder = new DiscordMessageBuilder()
-                        .WithContent(Helperfunctions.getTeamPing())
-                        .AddComponents(votebuttons)
-                        .AddEmbed(vembed);
-
-                    await message.ModifyAsync(builder);
-                    await conn.CloseAsync();
+                    await UpdateSingleVoteMessage(client, antragchannelid, messageId, expiresAt, pvotes, nvotes);
                 }
             }
             catch (Exception ex)
             {
                 //
             }
+
             await Task.Delay(TimeSpan.FromMinutes(5));
         }
     }
 
-    private static int getVoteColor(int pvotes, int nvotes)
+    public static async Task UpdateSingleVoteMessage(DiscordClient client, long antragchannelid, ulong messageId,
+        long expiresAt, int pvotes, int nvotes)
     {
-        if (pvotes == 0 && nvotes == 0)
-            return -1; // No votes → gray (default)
-        if (pvotes == nvotes)
-            return 2; // Tie → yellow
-        if (pvotes > nvotes)
-            return 1; // More positive votes → green
+        try
+        {
+            ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
+            DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
+            DiscordMessage message = await votechannel.GetMessageAsync(messageId);
 
-        return 0; // More negative votes → red
+            int color = Helperfunctions.getVoteColor(pvotes, nvotes);
+            DiscordEmbed vembed = MessageGenerator.getVoteEmbedInRunning(votechannel, expiresAt, nvotes, pvotes, color);
+
+            var votebuttons = new List<DiscordButtonComponent>
+            {
+                new(ButtonStyle.Secondary, "vote_yes_" + antragchannelid, "👍 Ja"),
+                new(ButtonStyle.Secondary, "vote_no_" + antragchannelid, "👎 Nein")
+            };
+
+            DiscordMessageBuilder builder = new DiscordMessageBuilder()
+                .WithContent(Helperfunctions.getTeamPing())
+                .AddComponents(votebuttons)
+                .AddEmbed(vembed);
+
+            await message.ModifyAsync(builder);
+        }
+        catch (Exception ex)
+        {
+            //
+        }
     }
-    
+
+    public static async Task UpdateSingleVoteMessage(DiscordClient client, ulong messageId)
+    {
+        try
+        {
+            string dbstring = Helperfunctions.DbString();
+            await using var conn = new NpgsqlConnection(dbstring);
+            await conn.OpenAsync();
+            await using var cmd = new NpgsqlCommand("SELECT * FROM abstimmungen WHERE message_id = @msgid", conn);
+            cmd.Parameters.AddWithValue("msgid", (long)messageId);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                long antragchannelid = reader.GetInt64(0);
+                long expiresAt = reader.GetInt64(2);
+                int pvotes = reader.GetInt32(4);
+                int nvotes = reader.GetInt32(5);
+                Console.WriteLine($"{antragchannelid}: {messageId}");
+                Console.WriteLine($"Updating vote message {messageId} in channel {antragchannelid} with expires at {expiresAt}, pvotes: {pvotes}, nvotes: {nvotes}");
+                await UpdateSingleVoteMessage(client, antragchannelid, messageId, expiresAt, pvotes, nvotes);
+            }
+        }
+        catch (Exception ex)
+        {
+            //
+        }
+
+    }
 }


### PR DESCRIPTION
### Description of Changes
This PR will add a change where buttons instead of reactions will be used

### Rationale behind Changes
Votings remain anonymous (everyone has their own reasons), better internal processing with fewer API requests since everything is stored in the database, and a more native Discord look.

### Did you use AI to help find, test, or implement this issue or feature?
no