### PR TITLE
Early Vote Conclusion

### DIFF
--- a/AGC Entbannungssystem.csproj
+++ b/AGC Entbannungssystem.csproj
@@ -21,8 +21,4 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <Folder Include="src\Enums\"/>
-    </ItemGroup>
-
 </Project>

--- a/src/Enums/VoteType.cs
+++ b/src/Enums/VoteType.cs
@@ -1,0 +1,7 @@
+﻿namespace AGC_Entbannungssystem.Enums;
+
+public enum VoteType
+{
+    Positive,
+    Negative
+}

--- a/src/Tasks/CheckExpiredVotes.cs
+++ b/src/Tasks/CheckExpiredVotes.cs
@@ -24,7 +24,7 @@ public class CheckExpiredVotes
                 await conn.OpenAsync();
                 await using NpgsqlCommand cmd = new NpgsqlCommand();
                 cmd.Connection = conn;
-                cmd.CommandText = "SELECT * FROM abstimmungen WHERE expires_at < @endtime";
+                cmd.CommandText = "SELECT * FROM abstimmungen WHERE expires_at < @endtime OR endpending = true";
                 cmd.Parameters.AddWithValue("endtime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
                 await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync();
                 // get all expired votes
@@ -66,7 +66,7 @@ public class CheckExpiredVotes
                 await conn2.OpenAsync();
                 await using var cmd2 = new NpgsqlCommand();
                 cmd2.Connection = conn2;
-                cmd2.CommandText = "DELETE FROM abstimmungen WHERE expires_at < @endtime";
+                cmd2.CommandText = "DELETE FROM abstimmungen WHERE expires_at < @endtime OR endpending = true";
                 cmd2.Parameters.AddWithValue("endtime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
                 await cmd2.ExecuteNonQueryAsync();
                 // abstimmungen_teamler delete voteid
@@ -74,7 +74,7 @@ public class CheckExpiredVotes
                 cmd3.Connection = conn2;
                 // voteid is channelid+messageid
                 cmd3.CommandText = "DELETE FROM abstimmungen_teamler WHERE vote_id IN " +
-                                   "(SELECT channel_id || '_' || message_id FROM abstimmungen WHERE expires_at < @endtime)";
+                                   "(SELECT channel_id || '_' || message_id FROM abstimmungen WHERE expires_at < @endtime OR endpending = true)";
                 cmd3.Parameters.AddWithValue("endtime", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
                 await cmd3.ExecuteNonQueryAsync();
                 await conn2.CloseAsync();


### PR DESCRIPTION
### Description of Changes
This implementation adds functionality to automatically conclude votes in the following scenarios:
1. When more than 70% of team members have participated and there is no tie
2. When the vote outcome is mathematically decided, even if less than 70% of members have voted
3. When votes are withdrawn, the system will check if the conditions are still met

### Rationale behind Changes
Remove unneccessary waiting time | closes #21 

### Suggested Testing Steps
//

### Expected behaviour
- When less than 70% of team members have voted and the outcome is not mathematically decided, the vote should remain active until its expiration time
- When more than 70% of team members have voted and there is no tie, the vote should be automatically concluded
- If there is a tie (equal number of positive and negative votes), the vote should continue even if more than 70% of team members have voted
- If votes are withdrawn and the percentage of team members who voted falls below 70% and the outcome is not mathematically decided, the vote should continue (endpending is set back to false)
- When the vote outcome is mathematically decided (e.g., 6 positive votes out of 10 members), the vote should be automatically concluded even if less than 70% of members have voted
- The vote conclusion process should be the same as for expired votes (message deleted, results posted, database entries cleaned up)

### Did you use AI to help find, test, or implement this issue or feature?
Used a AI Agent to speedup the implementation itself, everything was reviewed by me and tested