### PR TITLE
Add votestats command and fix vote message embed

### DIFF
--- a/src/Commands/VoteStats.cs
+++ b/src/Commands/VoteStats.cs
@@ -1,0 +1,118 @@
+using AGC_Entbannungssystem.Helpers;
+using AGC_Entbannungssystem.Services;
+using DisCatSharp.ApplicationCommands;
+using DisCatSharp.ApplicationCommands.Attributes;
+using DisCatSharp.ApplicationCommands.Context;
+using DisCatSharp.Entities;
+using DisCatSharp.Enums;
+
+namespace AGC_Entbannungssystem.Commands;
+
+public sealed class VoteStats : ApplicationCommandsModule
+{
+    [ApplicationCommandRequirePermissions(Permissions.Administrator)]
+    [SlashCommand("votestats", "Zeigt die Abstimmungsstatistiken an.")]
+    public async Task votestats(InteractionContext ctx,
+        [Option("antragskanal", "Der Kanal, in dem der Antrag gestellt wurde.")]
+        DiscordChannel channel)
+    {
+        if (!await isChannelInVotingChannel(channel))
+        {
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                new DiscordInteractionResponseBuilder().WithContent("Dieser Kanal ist nicht in einer Abstimmung!"));
+            return;
+        }
+
+        string dbstring = Helperfunctions.DbString();
+        await using var conn = new Npgsql.NpgsqlConnection(dbstring);
+        await conn.OpenAsync();
+        await using var cmd = new Npgsql.NpgsqlCommand("SELECT * FROM abstimmungen WHERE antragskanal = @channelid", conn);
+        cmd.Parameters.AddWithValue("channelid", channel.Id);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                new DiscordInteractionResponseBuilder().WithContent("Keine Abstimmung für diesen Kanal gefunden!"));
+            return;
+        }
+        long messageId = reader.GetInt64(1);
+        long expiresAt = reader.GetInt64(2);
+        int pvotes = reader.GetInt32(4);
+        int nvotes = reader.GetInt32(5);
+        bool endpending = reader.GetBoolean(6);
+        var createdby = reader.GetString(3);
+        
+        await reader.CloseAsync();
+        DiscordChannel voteChannel = await ctx.Client.GetChannelAsync(ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId")));
+        DiscordMessage voteMessage = await voteChannel.GetMessageAsync((ulong)messageId);
+        var voteid = (long)voteMessage.Id + (long)voteChannel.Id;
+        int color = Helperfunctions.getVoteColor(pvotes, nvotes);
+        await using var cmd2 = new Npgsql.NpgsqlCommand("SELECT * FROM abstimmungen_teamler WHERE abstimmung_id = @messageid", conn);
+        cmd2.Parameters.AddWithValue("messageid", messageId);
+        await using var reader2 = await cmd2.ExecuteReaderAsync();
+        var positiveVotes = new List<string>();
+        var negativeVotes = new List<string>();
+        while (await reader2.ReadAsync())
+        {
+            long userId = reader2.GetInt64(0);
+            bool voteValue = reader2.GetBoolean(1);
+            if (voteValue)
+            {
+                positiveVotes.Add(IdToMention(userId));
+            }
+            else
+            {
+                negativeVotes.Add(IdToMention(userId));
+            }
+        }
+        var voteEmbed = new DiscordEmbedBuilder()
+            .WithTitle("Abstimmungsstatistiken")
+            .WithDescription($"Abstimmung für den Antrag ``{channel.Name}`` | ({channel.Mention})\n" +
+                             $"**Positive Stimmen:** {pvotes}\n" +
+                             $"**User, die Positiv abgestimmt haben:**\n" +
+                                $"{(positiveVotes.Count > 0 ? string.Join(", ", positiveVotes) : "Keine positiven Stimmen")}\n\n" +
+                             $"**Negative Stimmen:** {nvotes}\n" +
+                                $"**User, die Negativ abgestimmt haben:**\n" +
+                                    $"{(negativeVotes.Count > 0 ? string.Join(", ", negativeVotes) : "Keine negativen Stimmen")}\n\n" +
+                             $"Die Abstimmung endet am <t:{expiresAt}:f> (<t:{expiresAt}:R>)\n\n" +
+                             $"**Abstimmung erstellt von:** {IdToMention(long.Parse(createdby))}\n" +
+                             $"**Abstimmung ID:** {voteid}\n" +
+                             $"{(endpending ? $"Die Abstimmung ist noch nicht beendet. Endet: <t:{expiresAt}:f> (<t:{expiresAt}:R>)" : "Die Abstimmung ist bereits beendet.")}")
+            .WithColor(color);
+        
+        // usual format is antrag-0000
+        var antragsnummer = channel.Name.Split('-').LastOrDefault()?.Trim();
+        var jumpToVoteButton = new DiscordLinkButtonComponent(
+            $"https://discord.com/channels/{ctx.Guild.Id}/{voteChannel.Id}/{voteMessage.Id}", $"Zur Abstimmung springen");
+        var jumpToAntragButton = new DiscordLinkButtonComponent(
+            $"https://discord.com/channels/{ctx.Guild.Id}/{channel.Id}", $"Zum Antrag {antragsnummer} springen");
+        var responseBuilder = new DiscordInteractionResponseBuilder()
+            .AddEmbed(voteEmbed.Build())
+            .AddComponents(jumpToAntragButton, jumpToVoteButton)
+            .AsEphemeral();
+        await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, responseBuilder);
+    }
+    
+    private static string IdToMention(ulong id)
+    {
+        return $"<@{id}>";
+    }
+
+    private static string IdToMention(long id)
+    {
+        return IdToMention((ulong)id);
+    }
+    
+    private static async Task<bool> isChannelInVotingChannel(DiscordChannel channel)
+    {
+        string dbstring = Helperfunctions.DbString();
+        await using var conn = new Npgsql.NpgsqlConnection(dbstring);
+        await conn.OpenAsync();
+        await using var cmd = new Npgsql.NpgsqlCommand("SELECT * FROM abstimmungen WHERE antragskanal = @channelid", conn);
+        cmd.Parameters.AddWithValue("channelid", channel.Id);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        return await reader.ReadAsync();
+    }
+}
+    
+    

--- a/src/Tasks/UpdateVoteMessages.cs
+++ b/src/Tasks/UpdateVoteMessages.cs
@@ -52,9 +52,11 @@ public static class UpdateVoteMessages
             ulong votechannelid = ulong.Parse(BotConfigurator.GetConfig("MainConfig", "AbstimmungsChannelId"));
             DiscordChannel votechannel = await client.GetChannelAsync(votechannelid);
             DiscordMessage message = await votechannel.GetMessageAsync(messageId);
+            
+            DiscordChannel antragchannel = await client.GetChannelAsync((ulong)antragchannelid);
 
             int color = Helperfunctions.getVoteColor(pvotes, nvotes);
-            DiscordEmbed vembed = MessageGenerator.getVoteEmbedInRunning(votechannel, expiresAt, nvotes, pvotes, color);
+            DiscordEmbed vembed = MessageGenerator.getVoteEmbedInRunning(antragchannel, expiresAt, nvotes, pvotes, color);
 
             var votebuttons = new List<DiscordButtonComponent>
             {


### PR DESCRIPTION
### Description of Changes
- Implemented a new `votestats` command to display voting statistics for a specified channel.
- Fixed an issue in the vote message embed to ensure the correct channel is used for displaying votes.

### Rationale behind Changes
The new `votestats` command provides an easy way for users to view voting statistics for a channel. The fix to the vote message embed resolves incorrect display behavior, ensuring accuracy in the voting feature.

### Suggested Testing Steps
- Test the `votestats` command with different channels to ensure statistics are displayed correctly.
- Verify that the vote message embed reflects the appropriate channel during voting processes.

### Did you use AI to help find, test, or implement this issue or feature?
No